### PR TITLE
Fixed top margin between jumbobox and body of page

### DIFF
--- a/src/ui/portal/src/views/Home.vue
+++ b/src/ui/portal/src/views/Home.vue
@@ -13,7 +13,7 @@
     </div>
 
     <div class="container">
-      <div class="row">
+      <div class="row mt-3">
         <div class="col-12 col-lg-4 mb-3">
           <div class="card">
             <div class="card-body">


### PR DESCRIPTION
The body top margin needs to have some space between the Jumbobox... This PR fixes the issue.

![bitmoji](https://render.bitstrips.com/v2/cpanel/4d8b3130-c973-4622-9695-60cf577fec44-b427cfda-a7f5-497f-a483-1061dc3d44a5-v1.png?transparent=1&palette=1&width=246)