### PR TITLE
Identify recipient on gramercy, (hopefully) addresses #34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Added margin to the top of main content to separate from the jumbotron
+- Added recipient Twitter handle on gramercy card,
+  enabling selective moderation for tweets with multiple mentions
 
 ## [1.0.0]
 

--- a/src/ui/portal/src/components/Gramercy.vue
+++ b/src/ui/portal/src/components/Gramercy.vue
@@ -4,9 +4,9 @@
       <blockquote class="blockquote mb-0">
         <p>{{message}}</p>
         <footer class="blockquote-footer" v-if="!isAnonymous">
-          <a v-bind:href="twitterUrl" target="_blank">{{senderHandle}}</a>
+          <a v-bind:href="senderTwitterUrl" target="_blank">{{senderHandle}}</a> for <a v-bind:href="recipientTwitterUrl" target="_blank">{{recipientHandle}}</a>
         </footer>
-        <footer class="blockquote-footer" v-else>Anonymous</footer>
+        <footer class="blockquote-footer" v-else>Anonymous</footer> for <a v-bind:href="recipientTwitterUrl" target="_blank">{{recipientHandle}}</a>
       </blockquote>
     </div>
     <div class="card-footer" v-if="moderate">
@@ -39,13 +39,17 @@ export default {
     id: String,
     message: String,
     senderHandle: String,
+    recipientHandle: String,
     status: Number,
     moderate: Boolean
   },
   computed: {
     ...mapState(["loading"]),
-    twitterUrl: function() {
+    senderTwitterUrl: function() {
       return `https://twitter.com/${this.senderHandle}`;
+    },
+    recipientTwitterUrl: function() {
+      return `https://twitter.com/${this.recipientHandle}`;
     },
     isAnonymous: function() {
       return (

--- a/src/ui/portal/src/components/Gramercy.vue
+++ b/src/ui/portal/src/components/Gramercy.vue
@@ -3,11 +3,11 @@
     <div class="card-body">
       <blockquote class="blockquote mb-0">
         <p>{{message}}</p>
-        <footer class="blockquote-footer" v-if="!isAnonymous">
-          <a v-bind:href="senderTwitterUrl" target="_blank">{{senderHandle}}</a>
+        <footer>
+          <a v-if="!isAnonymous" v-bind:href="senderTwitterUrl" target="_blank">{{senderHandle}}</a>
+          <span v-else>Anonymous</span>
+          <span> for <a v-bind:href="recipientTwitterUrl" target="_blank">{{recipientHandle}}</a><span>
         </footer>
-        <footer class="blockquote-footer" v-else>Anonymous</footer>
-         for <a v-bind:href="recipientTwitterUrl" target="_blank">{{recipientHandle}}</a>
       </blockquote>
     </div>
     <div class="card-footer" v-if="moderate">

--- a/src/ui/portal/src/components/Gramercy.vue
+++ b/src/ui/portal/src/components/Gramercy.vue
@@ -4,9 +4,10 @@
       <blockquote class="blockquote mb-0">
         <p>{{message}}</p>
         <footer class="blockquote-footer" v-if="!isAnonymous">
-          <a v-bind:href="senderTwitterUrl" target="_blank">{{senderHandle}}</a> for <a v-bind:href="recipientTwitterUrl" target="_blank">{{recipientHandle}}</a>
+          <a v-bind:href="senderTwitterUrl" target="_blank">{{senderHandle}}</a>
         </footer>
-        <footer class="blockquote-footer" v-else>Anonymous</footer> for <a v-bind:href="recipientTwitterUrl" target="_blank">{{recipientHandle}}</a>
+        <footer class="blockquote-footer" v-else>Anonymous</footer>
+         for <a v-bind:href="recipientTwitterUrl" target="_blank">{{recipientHandle}}</a>
       </blockquote>
     </div>
     <div class="card-footer" v-if="moderate">


### PR DESCRIPTION
I'm a little rusty around my C#, but I'm hoping this is good for addressing issue #34.

This adds the recipientHandle property, changes the existing `twitterUrl` to a more specific `senderTwitterUrl` so as to not be confused with the new `recipientTwitterUrl`.

Lines 7 and 9 are longer than I'd like, I wasn't sure what options are available for breaking those lines inside a Vue template.

I could build this locally, and it succeeded, but I couldn't actually test that the functionality works. All going well, the attribution under the message should now look something like:

`— @WindosNZ for @MichaelJolley`